### PR TITLE
7. Evaluating Expressions

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,16 +11,16 @@ One thing to note is that I'm trying to write a mix between idiomatic Swift (wha
 
 # Implementation
 
-*as of 30/03/2017*
+*as of 31/05/2017*
 
 ## A TREE-WALK INTERPRETER
 
 - [x] 4.  [**Scanning**](http://www.craftinginterpreters.com/scanning.html) - [Lox Interpreter in Swift](http://alejandromp.com/blog/2017/1/30/lox-interpreter-in-swift/)
-  - Including C-style /* ... */ block comments. (Challenge 4)
+  - [x] Challenge 4: C-style /* ... */ block comments.
 
 - [x] 5.  [**Representing Code**](http://www.craftinginterpreters.com/representing-code.html)
-  - Including AST Printer In Reverse Polish Notation. (Challenge 3)
-  - Including GenerateAst tool
+  - [x] Challenge 3: AST Printer In Reverse Polish Notation.
+  - [x] GenerateAst tool
   - Things to explore:
     - Is there a better way to metaprogram the expression classes? Or is there even a need to metaprogram them with Swift cleaner syntax?
     - Does Swift offer a better model for defining the expressions? 
@@ -31,7 +31,12 @@ One thing to note is that I'm trying to write a mix between idiomatic Swift (wha
   - [ ] Challenge 1: Add prefix and postfix ++ and -- operators.
   - [ ] Challenge 2: Add support for the C-style conditional or “ternary” operator `?:`
   - [ ] Challenge 3: Add error productions to handle each binary operator appearing without a left-hand operand.
-- [ ] 7. [**Evaluating Expressions**](http://www.craftinginterpreters.com/evaluating-expressions.html) (COMING SOON)
+
+- [x] 7. [**Evaluating Expressions**](http://www.craftinginterpreters.com/evaluating-expressions.html)
+  - [ ] Challenge 1: Allowing comparisons on types other than numbers could be useful.
+  - [ ] Challenge 2: Many languages define + such that if either operand is a string, the other is converted to a string and the results are then concatenated.
+  - [ ] Challenge 3: Change the implementation in visitBinary() to detect and report a runtime error when dividing by 0. 
+
 - [ ] 8. [**Statements and State**](http://www.craftinginterpreters.com/statements-and-state.html) (COMING SOON)
 - [ ] 9. [**Control Flow**](http://www.craftinginterpreters.com/control-flow.html) (COMING SOON)
 - [ ] 10. [**Functions**](http://www.craftinginterpreters.com/functions.html) (COMING SOON)

--- a/slox/slox.xcodeproj/project.pbxproj
+++ b/slox/slox.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		FB5387B41EDD824A003DE00B /* Interpreter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB5387B31EDD824A003DE00B /* Interpreter.swift */; };
 		FB55B8921E3E7C94002D7372 /* main.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB55B8911E3E7C94002D7372 /* main.swift */; };
 		FB55B8991E3E7E0F002D7372 /* Lox.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB55B8981E3E7E0F002D7372 /* Lox.swift */; };
 		FB55B89B1E3E7F84002D7372 /* Scanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB55B89A1E3E7F84002D7372 /* Scanner.swift */; };
@@ -29,6 +30,7 @@
 /* End PBXCopyFilesBuildPhase section */
 
 /* Begin PBXFileReference section */
+		FB5387B31EDD824A003DE00B /* Interpreter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Interpreter.swift; sourceTree = "<group>"; };
 		FB55B88E1E3E7C94002D7372 /* slox */ = {isa = PBXFileReference; explicitFileType = "compiled.mach-o.executable"; includeInIndex = 0; path = slox; sourceTree = BUILT_PRODUCTS_DIR; };
 		FB55B8911E3E7C94002D7372 /* main.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = main.swift; sourceTree = "<group>"; };
 		FB55B8981E3E7E0F002D7372 /* Lox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lox.swift; sourceTree = "<group>"; };
@@ -73,6 +75,7 @@
 				FB55B8981E3E7E0F002D7372 /* Lox.swift */,
 				FB55B89A1E3E7F84002D7372 /* Scanner.swift */,
 				FB77963E1E8CD8BC001599C1 /* Parser.swift */,
+				FB5387B31EDD824A003DE00B /* Interpreter.swift */,
 				FB55B89C1E3F1F31002D7372 /* Token.swift */,
 				FB9501001E56E132006C2A81 /* Expr.swift */,
 				FB9501021E5700FD006C2A81 /* AstPrinter.swift */,
@@ -156,6 +159,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				FB5387B41EDD824A003DE00B /* Interpreter.swift in Sources */,
 				FB9501011E56E132006C2A81 /* Expr.swift in Sources */,
 				FB55B8921E3E7C94002D7372 /* main.swift in Sources */,
 				FB55B89B1E3E7F84002D7372 /* Scanner.swift in Sources */,

--- a/slox/slox.xcodeproj/project.pbxproj
+++ b/slox/slox.xcodeproj/project.pbxproj
@@ -12,6 +12,10 @@
 		FB55B8991E3E7E0F002D7372 /* Lox.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB55B8981E3E7E0F002D7372 /* Lox.swift */; };
 		FB55B89B1E3E7F84002D7372 /* Scanner.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB55B89A1E3E7F84002D7372 /* Scanner.swift */; };
 		FB55B89D1E3F1F31002D7372 /* Token.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB55B89C1E3F1F31002D7372 /* Token.swift */; };
+		FB6C0F8A1EDF4C4F0098C3DF /* AnyError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB6C0F841EDF4C4F0098C3DF /* AnyError.swift */; };
+		FB6C0F8B1EDF4C4F0098C3DF /* NoError.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB6C0F861EDF4C4F0098C3DF /* NoError.swift */; };
+		FB6C0F8C1EDF4C4F0098C3DF /* Result.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB6C0F881EDF4C4F0098C3DF /* Result.swift */; };
+		FB6C0F8D1EDF4C4F0098C3DF /* ResultProtocol.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB6C0F891EDF4C4F0098C3DF /* ResultProtocol.swift */; };
 		FB77963F1E8CD8BC001599C1 /* Parser.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB77963E1E8CD8BC001599C1 /* Parser.swift */; };
 		FB9501011E56E132006C2A81 /* Expr.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB9501001E56E132006C2A81 /* Expr.swift */; };
 		FB9501031E5700FD006C2A81 /* AstPrinter.swift in Sources */ = {isa = PBXBuildFile; fileRef = FB9501021E5700FD006C2A81 /* AstPrinter.swift */; };
@@ -36,6 +40,10 @@
 		FB55B8981E3E7E0F002D7372 /* Lox.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Lox.swift; sourceTree = "<group>"; };
 		FB55B89A1E3E7F84002D7372 /* Scanner.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Scanner.swift; sourceTree = "<group>"; };
 		FB55B89C1E3F1F31002D7372 /* Token.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Token.swift; sourceTree = "<group>"; };
+		FB6C0F841EDF4C4F0098C3DF /* AnyError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AnyError.swift; sourceTree = "<group>"; };
+		FB6C0F861EDF4C4F0098C3DF /* NoError.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NoError.swift; sourceTree = "<group>"; };
+		FB6C0F881EDF4C4F0098C3DF /* Result.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Result.swift; sourceTree = "<group>"; };
+		FB6C0F891EDF4C4F0098C3DF /* ResultProtocol.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = ResultProtocol.swift; sourceTree = "<group>"; };
 		FB77963E1E8CD8BC001599C1 /* Parser.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Parser.swift; sourceTree = "<group>"; };
 		FB9501001E56E132006C2A81 /* Expr.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = Expr.swift; sourceTree = "<group>"; };
 		FB9501021E5700FD006C2A81 /* AstPrinter.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = AstPrinter.swift; sourceTree = "<group>"; };
@@ -71,6 +79,7 @@
 		FB55B8901E3E7C94002D7372 /* slox */ = {
 			isa = PBXGroup;
 			children = (
+				FB6C0F831EDF4C4F0098C3DF /* Result */,
 				FB55B8911E3E7C94002D7372 /* main.swift */,
 				FB55B8981E3E7E0F002D7372 /* Lox.swift */,
 				FB55B89A1E3E7F84002D7372 /* Scanner.swift */,
@@ -81,6 +90,17 @@
 				FB9501021E5700FD006C2A81 /* AstPrinter.swift */,
 			);
 			path = slox;
+			sourceTree = "<group>";
+		};
+		FB6C0F831EDF4C4F0098C3DF /* Result */ = {
+			isa = PBXGroup;
+			children = (
+				FB6C0F841EDF4C4F0098C3DF /* AnyError.swift */,
+				FB6C0F861EDF4C4F0098C3DF /* NoError.swift */,
+				FB6C0F881EDF4C4F0098C3DF /* Result.swift */,
+				FB6C0F891EDF4C4F0098C3DF /* ResultProtocol.swift */,
+			);
+			path = Result;
 			sourceTree = "<group>";
 		};
 /* End PBXGroup section */
@@ -162,11 +182,15 @@
 				FB5387B41EDD824A003DE00B /* Interpreter.swift in Sources */,
 				FB9501011E56E132006C2A81 /* Expr.swift in Sources */,
 				FB55B8921E3E7C94002D7372 /* main.swift in Sources */,
+				FB6C0F8A1EDF4C4F0098C3DF /* AnyError.swift in Sources */,
 				FB55B89B1E3E7F84002D7372 /* Scanner.swift in Sources */,
 				FB55B8991E3E7E0F002D7372 /* Lox.swift in Sources */,
 				FB55B89D1E3F1F31002D7372 /* Token.swift in Sources */,
+				FB6C0F8B1EDF4C4F0098C3DF /* NoError.swift in Sources */,
+				FB6C0F8D1EDF4C4F0098C3DF /* ResultProtocol.swift in Sources */,
 				FB9501031E5700FD006C2A81 /* AstPrinter.swift in Sources */,
 				FB77963F1E8CD8BC001599C1 /* Parser.swift in Sources */,
+				FB6C0F8C1EDF4C4F0098C3DF /* Result.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/slox/slox/Expr.swift
+++ b/slox/slox/Expr.swift
@@ -3,6 +3,9 @@ protocol Visitor {
 
     associatedtype Return
 
+    // Decided to make the Visitor methods non-throwing to avoid polluting with throws
+    // the visitors that don't return errors. Instead if an error has to be returnen
+    // the specific visitor implementation will return a Result type.
     func visitBinaryExpr(_ expr: Expr.Binary) -> Return
     func visitGroupingExpr(_ expr: Expr.Grouping) -> Return
     func visitLiteralExpr(_ expr: Expr.Literal) -> Return

--- a/slox/slox/Expr.swift
+++ b/slox/slox/Expr.swift
@@ -4,7 +4,7 @@ protocol Visitor {
     associatedtype Return
 
     // Decided to make the Visitor methods non-throwing to avoid polluting with throws
-    // the visitors that don't return errors. Instead if an error has to be returnen
+    // the visitors that don't return errors. Instead if an error has to be returned
     // the specific visitor implementation will return a Result type.
     func visitBinaryExpr(_ expr: Expr.Binary) -> Return
     func visitGroupingExpr(_ expr: Expr.Grouping) -> Return

--- a/slox/slox/Interpreter.swift
+++ b/slox/slox/Interpreter.swift
@@ -1,0 +1,254 @@
+//
+//  Interpreter.swift
+//  slox
+//
+//  Created by Alejandro Martinez on 30/05/2017.
+//  Copyright © 2017 Alejandro Martinez. All rights reserved.
+//
+
+import Foundation
+
+enum InterpreterError: Error {
+    case runtime(Token, String) // TODO: Instead of string we could have different cases for each error.
+}
+
+enum Result<T> {
+    case success(T)
+    case error(Error)
+
+    func map<R>(_ f: ((T) -> R)) -> Result<R> {
+        switch self {
+        case .error(let e):
+            return .error(e)
+        case .success(let r):
+            return .success(f(r))
+        }
+    }
+}
+
+final class Interpreter: Visitor {
+    typealias Return = Result<Any>?
+
+    func interpret(_ expression: Expr) {
+        guard let value = evaluate(expr: expression) else {
+            print(stringify(value: nil))
+            return
+        }
+        switch value {
+        case .success(let v):
+            print(stringify(value: v))
+        case .error(let error):
+            runtimeError(error: error)
+        }
+    }
+
+    private func stringify(value: Any?) -> String {
+        guard let v = value else { return "nil" }
+
+        // TODO: Consider number formatting
+        return String(describing: v)
+    }
+
+    // MARK: Visitor
+
+    func visitLiteralExpr(_ expr: Expr.Literal) -> Result<Any>? {
+        guard let value = expr.value else {
+            return nil
+        }
+        return .success(value)
+    }
+
+    func visitGroupingExpr(_ expr: Expr.Grouping) -> Result<Any>? {
+        return .success(evaluate(expr: expr.expression))
+    }
+
+    func visitUnaryExpr(_ expr: Expr.Unary) -> Result<Any>? {
+        let right = evaluate(expr: expr.right)
+
+        switch expr.op.type {
+        case .bang:
+            return .success(!isTrue(object: right))
+        case .minus:
+            let casted = castNumberOperand(op: expr.op, operand: right)
+            return casted.map(-)
+
+        case .leftParen, .rightParen: fallthrough
+        case .leftBrace, .rightBrace: fallthrough
+        case .comma: fallthrough
+        case .dot: fallthrough
+        case .plus: fallthrough
+        case .semicolon: fallthrough
+        case .slash: fallthrough
+        case .star: fallthrough
+        case .bangEqual: fallthrough
+        case .equal: fallthrough
+        case .equalEqual: fallthrough
+        case .greater, .greaterEqual: fallthrough
+        case .less, .lessEqual: fallthrough
+        case .identifier: fallthrough
+        case .string: fallthrough
+        case .number: fallthrough
+        case .and: fallthrough
+        case .Class: fallthrough
+        case .Else: fallthrough
+        case .False: fallthrough
+        case .fun: fallthrough
+        case .For: fallthrough
+        case .If: fallthrough
+        case .Nil: fallthrough
+        case .or: fallthrough
+        case .print: fallthrough
+        case .Return: fallthrough
+        case .Super: fallthrough
+        case .this: fallthrough
+        case .True: fallthrough
+        case .Var: fallthrough
+        case .While: fallthrough
+        case .eof:
+            // Unreachable.
+            fatalError()
+        }
+    }
+
+    func visitBinaryExpr(_ expr: Expr.Binary) -> Result<Any>? {
+        let left = evaluate(expr: expr.left)
+        let right = evaluate(expr: expr.right)
+
+        switch expr.op.type {
+        case .minus:
+            return castNumberOperands(op: expr.op, left: expr.left, right: expr.right).map({ $0.0 - $0.1 })
+        case .slash:
+            return castNumberOperands(op: expr.op, left: expr.left, right: expr.right).map({ $0.0 / $0.1 })
+        case .star:
+            return castNumberOperands(op: expr.op, left: expr.left, right: expr.right).map({ $0.0 * $0.1 })
+        case .plus:
+
+            guard let left = left, let right = right else {
+                return .error(InterpreterError.runtime(expr.op, "Operands must be two numbers or two strings."))
+            }
+
+            guard case let .success(ls) = left, case let .success(rs) = right else {
+                return .error(InterpreterError.runtime(expr.op, "Operands must be two numbers or two strings."))
+            }
+
+            if let lDouble = ls as? Double, let rDouble = rs as? Double {
+                return .success(lDouble + rDouble)
+            }
+
+            if let lString = ls as? String, let rString = rs as? String {
+                return .success(lString + rString)
+            }
+
+            return .error(InterpreterError.runtime(expr.op, "Operands must be two numbers or two strings."))
+
+        case .greater:
+            return castNumberOperands(op: expr.op, left: expr.left, right: expr.right).map({ $0.0 > $0.1 })
+        case .greaterEqual:
+            return castNumberOperands(op: expr.op, left: expr.left, right: expr.right).map({ $0.0 >= $0.1 })
+        case .less:
+            return castNumberOperands(op: expr.op, left: expr.left, right: expr.right).map({ $0.0 < $0.1 })
+        case .lessEqual:
+            return castNumberOperands(op: expr.op, left: expr.left, right: expr.right).map({ $0.0 <= $0.1 })
+
+        case .bangEqual:
+            return .success(!isEqualAny(left: left, right: right))
+        case .equalEqual:
+            return .success(isEqualAny(left: left, right: right))
+
+        case .leftParen, .rightParen: fallthrough
+        case .leftBrace, .rightBrace: fallthrough
+        case .comma: fallthrough
+        case .dot: fallthrough
+        case .semicolon: fallthrough
+        case .bang: fallthrough
+        case .equal: fallthrough
+        case .identifier: fallthrough
+        case .string: fallthrough
+        case .number: fallthrough
+        case .and: fallthrough
+        case .Class: fallthrough
+        case .Else: fallthrough
+        case .False: fallthrough
+        case .fun: fallthrough
+        case .For: fallthrough
+        case .If: fallthrough
+        case .Nil: fallthrough
+        case .or: fallthrough
+        case .print: fallthrough
+        case .Return: fallthrough
+        case .Super: fallthrough
+        case .this: fallthrough
+        case .True: fallthrough
+        case .Var: fallthrough
+        case .While: fallthrough
+        case .eof:
+            // Unreachable.
+            fatalError()
+        }
+    }
+
+    private func evaluate(expr: Expr) -> Result<Any>? {
+        return expr.accept(visitor: self)
+    }
+
+    private func isTrue(object: Any?) -> Bool {
+        if object == nil {
+            return false
+        }
+
+        if let b = object as? Bool {
+            return b
+        }
+
+        return true
+    }
+
+    private func isEqualAny(left: Any?, right: Any?) -> Bool {
+        // nil is only equal to nil.
+        if left == nil && right == nil {
+            return true
+        }
+
+        if left == nil {
+            return false
+        }
+
+        /*
+         guard left.self == right.self else {
+         // Types are different.
+         return false
+         }*/
+
+        if let l = left as? String, let r = right as? String {
+            return l == r
+        }
+
+        if let l = left as? Bool, let r = right as? Bool {
+            return l == r
+        }
+
+        if let l = left as? Double, let r = right as? Double {
+            return l == r
+        }
+
+        fatalError("Unsupported equatable type. /n \(String(describing: left)) or \(String(describing: right))/nOR TYPES ARE JUST DIFFERET")
+    }
+
+    // MARK: Runtime checks
+
+    private func castNumberOperands(op: Token, left: Any?, right: Any?) -> Result<(Double, Double)> {
+        if let l = left as? Double, let r = right as? Double {
+            return .success(l, r)
+        }
+
+        return .error(InterpreterError.runtime(op, "Operands must be numbers."))
+    }
+
+    private func castNumberOperand(op: Token, operand: Any?) -> Result<Double> {
+        if let res = operand as? Double {
+            return .success(res)
+        }
+
+        return .error(InterpreterError.runtime(op, "Operand must be a number."))
+    }
+}

--- a/slox/slox/Parser.swift
+++ b/slox/slox/Parser.swift
@@ -84,18 +84,18 @@ final class Parser {
 
         throw error(token: peek(), message: "Expect expression.")
     }
-    
+
     // MARK: Helper
-    
+
     private func leftAssociativeBinary(expression side: () throws -> Expr, types: TokenType...) rethrows -> Expr {
         var expr = try side()
-        
+
         while match(types) {
             let op = previous()
             let right = try side()
             expr = Expr.Binary(left: expr, op: op, right: right)
         }
-        
+
         return expr
     }
 }

--- a/slox/slox/Result/AnyError.swift
+++ b/slox/slox/Result/AnyError.swift
@@ -1,0 +1,58 @@
+import Foundation
+
+/// A type-erased error which wraps an arbitrary error instance. This should be
+/// useful for generic contexts.
+public struct AnyError: Swift.Error {
+    /// The underlying error.
+    public let error: Swift.Error
+
+    public init(_ error: Swift.Error) {
+        if let anyError = error as? AnyError {
+            self = anyError
+        } else {
+            self.error = error
+        }
+    }
+}
+
+extension AnyError: ErrorConvertible {
+    public static func error(from error: Error) -> AnyError {
+        return AnyError(error)
+    }
+}
+
+extension AnyError: CustomStringConvertible {
+    public var description: String {
+        return String(describing: error)
+    }
+}
+
+extension AnyError: LocalizedError {
+    public var errorDescription: String? {
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+            return error.localizedDescription
+        #else
+            #if swift(>=4.0)
+                // The workaround below is not needed for Swift 4.0 thanks to
+                // https://github.com/apple/swift-corelibs-foundation/pull/967.
+            #else
+                if let nsError = error as? NSError {
+                    return nsError.localizedDescription
+                }
+            #endif
+            return error.localizedDescription
+        #endif
+    }
+
+    public var failureReason: String? {
+        return (error as? LocalizedError)?.failureReason
+    }
+
+    public var helpAnchor: String? {
+        return (error as? LocalizedError)?.helpAnchor
+    }
+
+    public var recoverySuggestion: String? {
+        return (error as? LocalizedError)?.recoverySuggestion
+    }
+}

--- a/slox/slox/Result/NoError.swift
+++ b/slox/slox/Result/NoError.swift
@@ -1,0 +1,10 @@
+/// An “error” that is impossible to construct.
+///
+/// This can be used to describe `Result`s where failures will never
+/// be generated. For example, `Result<Int, NoError>` describes a result that
+/// contains an `Int`eger and is guaranteed never to be a `failure`.
+public enum NoError: Swift.Error, Equatable {
+    public static func ==(lhs: NoError, rhs: NoError) -> Bool {
+        return true
+    }
+}

--- a/slox/slox/Result/Result.swift
+++ b/slox/slox/Result/Result.swift
@@ -1,0 +1,178 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+/// An enum representing either a failure with an explanatory error, or a success with a result value.
+public enum Result<T, Error: Swift.Error>: ResultProtocol, CustomStringConvertible, CustomDebugStringConvertible {
+    case success(T)
+    case failure(Error)
+
+    // MARK: Constructors
+
+    /// Constructs a success wrapping a `value`.
+    public init(value: T) {
+        self = .success(value)
+    }
+
+    /// Constructs a failure wrapping an `error`.
+    public init(error: Error) {
+        self = .failure(error)
+    }
+
+    /// Constructs a result from an `Optional`, failing with `Error` if `nil`.
+    public init(_ value: T?, failWith: @autoclosure () -> Error) {
+        self = value.map(Result.success) ?? .failure(failWith())
+    }
+
+    /// Constructs a result from a function that uses `throw`, failing with `Error` if throws.
+    public init(_ f: @autoclosure () throws -> T) {
+        self.init(attempt: f)
+    }
+
+    /// Constructs a result from a function that uses `throw`, failing with `Error` if throws.
+    public init(attempt f: () throws -> T) {
+        do {
+            self = .success(try f())
+        } catch var error {
+            if Error.self == AnyError.self {
+                error = AnyError(error)
+            }
+            self = .failure(error as! Error)
+        }
+    }
+
+    // MARK: Deconstruction
+
+    /// Returns the value from `success` Results or `throw`s the error.
+    public func dematerialize() throws -> T {
+        switch self {
+        case let .success(value):
+            return value
+        case let .failure(error):
+            throw error
+        }
+    }
+
+    /// Case analysis for Result.
+    ///
+    /// Returns the value produced by applying `ifFailure` to `failure` Results, or `ifSuccess` to `success` Results.
+    public func analysis<Result>(ifSuccess: (T) -> Result, ifFailure: (Error) -> Result) -> Result {
+        switch self {
+        case let .success(value):
+            return ifSuccess(value)
+        case let .failure(value):
+            return ifFailure(value)
+        }
+    }
+
+    // MARK: Errors
+
+    /// The domain for errors constructed by Result.
+    public static var errorDomain: String { return "com.antitypical.Result" }
+
+    /// The userInfo key for source functions in errors constructed by Result.
+    public static var functionKey: String { return "\(errorDomain).function" }
+
+    /// The userInfo key for source file paths in errors constructed by Result.
+    public static var fileKey: String { return "\(errorDomain).file" }
+
+    /// The userInfo key for source file line numbers in errors constructed by Result.
+    public static var lineKey: String { return "\(errorDomain).line" }
+
+    /// Constructs an error.
+    public static func error(_ message: String? = nil, function: String = #function, file: String = #file, line: Int = #line) -> NSError {
+        var userInfo: [String: Any] = [
+            functionKey: function,
+            fileKey: file,
+            lineKey: line,
+        ]
+
+        if let message = message {
+            userInfo[NSLocalizedDescriptionKey] = message
+        }
+
+        return NSError(domain: errorDomain, code: 0, userInfo: userInfo)
+    }
+
+    // MARK: CustomStringConvertible
+
+    public var description: String {
+        return analysis(
+            ifSuccess: { ".success(\($0))" },
+            ifFailure: { ".failure(\($0))" })
+    }
+
+    // MARK: CustomDebugStringConvertible
+
+    public var debugDescription: String {
+        return description
+    }
+}
+
+// MARK: - Derive result from failable closure
+
+public func materialize<T>(_ f: () throws -> T) -> Result<T, AnyError> {
+    return materialize(try f())
+}
+
+public func materialize<T>(_ f: @autoclosure () throws -> T) -> Result<T, AnyError> {
+    do {
+        return .success(try f())
+    } catch {
+        return .failure(AnyError(error))
+    }
+}
+
+// MARK: - Cocoa API conveniences
+
+#if !os(Linux)
+
+    /// Constructs a `Result` with the result of calling `try` with an error pointer.
+    ///
+    /// This is convenient for wrapping Cocoa API which returns an object or `nil` + an error, by reference. e.g.:
+    ///
+    ///     Result.try { NSData(contentsOfURL: URL, options: .dataReadingMapped, error: $0) }
+    public func `try`<T>(_ function: String = #function, file: String = #file, line: Int = #line, try: (NSErrorPointer) -> T?) -> Result<T, NSError> {
+        var error: NSError?
+        return `try`(&error).map(Result.success) ?? .failure(error ?? Result<T, NSError>.error(function: function, file: file, line: line))
+    }
+
+    /// Constructs a `Result` with the result of calling `try` with an error pointer.
+    ///
+    /// This is convenient for wrapping Cocoa API which returns a `Bool` + an error, by reference. e.g.:
+    ///
+    ///     Result.try { NSFileManager.defaultManager().removeItemAtURL(URL, error: $0) }
+    public func `try`(_ function: String = #function, file: String = #file, line: Int = #line, try: (NSErrorPointer) -> Bool) -> Result<(), NSError> {
+        var error: NSError?
+        return `try`(&error) ?
+            .success(())
+            : .failure(error ?? Result<(), NSError>.error(function: function, file: file, line: line))
+    }
+
+#endif
+
+// MARK: - ErrorConvertible conformance
+
+extension NSError: ErrorConvertible {
+    public static func error(from error: Swift.Error) -> Self {
+        func cast<T: NSError>(_ error: Swift.Error) -> T {
+            return error as! T
+        }
+
+        return cast(error)
+    }
+}
+
+// MARK: - migration support
+
+@available(*, unavailable, message: "Use the overload which returns `Result<T, AnyError>` instead")
+public func materialize<T>(_ f: () throws -> T) -> Result<T, NSError> {
+    fatalError()
+}
+
+@available(*, unavailable, message: "Use the overload which returns `Result<T, AnyError>` instead")
+public func materialize<T>(_ f: @autoclosure () throws -> T) -> Result<T, NSError> {
+    fatalError()
+}
+
+// MARK: -
+
+import Foundation

--- a/slox/slox/Result/ResultProtocol.swift
+++ b/slox/slox/Result/ResultProtocol.swift
@@ -1,0 +1,154 @@
+//  Copyright (c) 2015 Rob Rix. All rights reserved.
+
+/// A type that can represent either failure with an error or success with a result value.
+public protocol ResultProtocol {
+    associatedtype Value
+    associatedtype Error: Swift.Error
+
+    /// Constructs a successful result wrapping a `value`.
+    init(value: Value)
+
+    /// Constructs a failed result wrapping an `error`.
+    init(error: Error)
+
+    /// Case analysis for ResultProtocol.
+    ///
+    /// Returns the value produced by appliying `ifFailure` to the error if self represents a failure, or `ifSuccess` to the result value if self represents a success.
+    func analysis<U>(ifSuccess: (Value) -> U, ifFailure: (Error) -> U) -> U
+
+    /// Returns the value if self represents a success, `nil` otherwise.
+    ///
+    /// A default implementation is provided by a protocol extension. Conforming types may specialize it.
+    var value: Value? { get }
+
+    /// Returns the error if self represents a failure, `nil` otherwise.
+    ///
+    /// A default implementation is provided by a protocol extension. Conforming types may specialize it.
+    var error: Error? { get }
+}
+
+public extension ResultProtocol {
+
+    /// Returns the value if self represents a success, `nil` otherwise.
+    public var value: Value? {
+        return analysis(ifSuccess: { $0 }, ifFailure: { _ in nil })
+    }
+
+    /// Returns the error if self represents a failure, `nil` otherwise.
+    public var error: Error? {
+        return analysis(ifSuccess: { _ in nil }, ifFailure: { $0 })
+    }
+
+    /// Returns a new Result by mapping `Success`es’ values using `transform`, or re-wrapping `Failure`s’ errors.
+    public func map<U>(_ transform: (Value) -> U) -> Result<U, Error> {
+        return flatMap { .success(transform($0)) }
+    }
+
+    /// Returns the result of applying `transform` to `Success`es’ values, or re-wrapping `Failure`’s errors.
+    public func flatMap<U>(_ transform: (Value) -> Result<U, Error>) -> Result<U, Error> {
+        return analysis(
+            ifSuccess: transform,
+            ifFailure: Result<U, Error>.failure)
+    }
+
+    /// Returns a Result with a tuple of the receiver and `other` values if both
+    /// are `Success`es, or re-wrapping the error of the earlier `Failure`.
+    public func fanout<R: ResultProtocol>(_ other: @autoclosure () -> R) -> Result<(Value, R.Value), Error>
+        where Error == R.Error {
+        return flatMap { left in other().map { right in (left, right) } }
+    }
+
+    /// Returns a new Result by mapping `Failure`'s values using `transform`, or re-wrapping `Success`es’ values.
+    public func mapError<Error2>(_ transform: (Error) -> Error2) -> Result<Value, Error2> {
+        return flatMapError { .failure(transform($0)) }
+    }
+
+    /// Returns the result of applying `transform` to `Failure`’s errors, or re-wrapping `Success`es’ values.
+    public func flatMapError<Error2>(_ transform: (Error) -> Result<Value, Error2>) -> Result<Value, Error2> {
+        return analysis(
+            ifSuccess: Result<Value, Error2>.success,
+            ifFailure: transform)
+    }
+
+    /// Returns a new Result by mapping `Success`es’ values using `success`, and by mapping `Failure`'s values using `failure`.
+    public func bimap<U, Error2>(success: (Value) -> U, failure: (Error) -> Error2) -> Result<U, Error2> {
+        return analysis(
+            ifSuccess: { .success(success($0)) },
+            ifFailure: { .failure(failure($0)) }
+        )
+    }
+}
+
+public extension ResultProtocol {
+
+    // MARK: Higher-order functions
+
+    /// Returns `self.value` if this result is a .Success, or the given value otherwise. Equivalent with `??`
+    public func recover(_ value: @autoclosure () -> Value) -> Value {
+        return self.value ?? value()
+    }
+
+    /// Returns this result if it is a .Success, or the given result otherwise. Equivalent with `??`
+    public func recover(with result: @autoclosure () -> Self) -> Self {
+        return analysis(
+            ifSuccess: { _ in self },
+            ifFailure: { _ in result() })
+    }
+}
+
+/// Protocol used to constrain `tryMap` to `Result`s with compatible `Error`s.
+public protocol ErrorConvertible: Swift.Error {
+    static func error(from error: Swift.Error) -> Self
+}
+
+public extension ResultProtocol where Error: ErrorConvertible {
+
+    /// Returns the result of applying `transform` to `Success`es’ values, or wrapping thrown errors.
+    public func tryMap<U>(_ transform: (Value) throws -> U) -> Result<U, Error> {
+        return flatMap { value in
+            do {
+                return .success(try transform(value))
+            } catch {
+                let convertedError = Error.error(from: error)
+                // Revisit this in a future version of Swift. https://twitter.com/jckarter/status/672931114944696321
+                return .failure(convertedError)
+            }
+        }
+    }
+}
+
+// MARK: - Operators
+
+extension ResultProtocol where Value: Equatable, Error: Equatable {
+    /// Returns `true` if `left` and `right` are both `Success`es and their values are equal, or if `left` and `right` are both `Failure`s and their errors are equal.
+    public static func ==(left: Self, right: Self) -> Bool {
+        if let left = left.value, let right = right.value {
+            return left == right
+        } else if let left = left.error, let right = right.error {
+            return left == right
+        }
+        return false
+    }
+
+    /// Returns `true` if `left` and `right` represent different cases, or if they represent the same case but different values.
+    public static func !=(left: Self, right: Self) -> Bool {
+        return !(left == right)
+    }
+}
+
+extension ResultProtocol {
+    /// Returns the value of `left` if it is a `Success`, or `right` otherwise. Short-circuits.
+    public static func ??(left: Self, right: @autoclosure () -> Value) -> Value {
+        return left.recover(right())
+    }
+
+    /// Returns `left` if it is a `Success`es, or `right` otherwise. Short-circuits.
+    public static func ??(left: Self, right: @autoclosure () -> Self) -> Self {
+        return left.recover(with: right())
+    }
+}
+
+// MARK: - migration support
+
+@available(*, unavailable, renamed: "ErrorConvertible")
+public protocol ErrorProtocolConvertible: ErrorConvertible {}

--- a/slox/slox/Scanner.swift
+++ b/slox/slox/Scanner.swift
@@ -132,7 +132,7 @@ final class Scanner {
             identifier()
 
         default:
-            error(line: line, message: "Unexpected character.")
+            error(line: line, message: "Unexpected character. '\(c)'")
         }
     }
 


### PR DESCRIPTION
- This has been a nice exercise on using Result instead of Swift native error handling. See https://github.com/alexito4/slox/blob/575bae9d08bd6047035ee76f77de0808440ee54a/slox/slox/Expr.swift#L8 I wish Swift error handling was more flexible and allowed to interoperate with the Result type. For now I dropped the source files of https://github.com/antitypical/Result into the project but I should be moving it to use SPM now that seems more usable.
- I feel like the `InterpreterError` would be much nicer if it actually had different cases for each error, but for now that's enough. 
- Setting up the switch statements to fallthrough for the unused operations has been a pain in the ass but I feel like it would pay dividends in the future if there is the need to add more operations or refactor some stuff. I wish there was a better way, like "default but only until the enum is modified".
- Also at this point I should start integrating tests from the book repo's.

- [x] Update README with chapter 7 done
- [x] Update README with chapter 7 challenges
